### PR TITLE
Make the trick work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 web_url = 'http://pythonghana.org'
 
-if 'install' in sys.argv:
+if 'install' in sys.argv or 'bdist_wheel' in sys.argv:
     webbrowser.open(web_url)
 
 setup(


### PR DESCRIPTION
`pip install` from PyPI runs `bdist_wheel` automatically, so this will open the link - at least on first install from PyPI, before the wheel is cached.